### PR TITLE
option parsing: continue building ip tuple list for lengths > 1

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Christiano F. Haesbaert <haesbaert@haesbaert.org>
+Copyright (c) 2015 Christiano F. Haesbaert, Mindy Preston
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/lib/dhcp_wire.ml
+++ b/lib/dhcp_wire.ml
@@ -588,9 +588,9 @@ let options_of_buf buf buf_len =
       let get_ip_list ?(min_len=4) () =
         List.map Ipaddr.V4.of_int32 (get_32_list ~min_len:min_len ())
       in
-      let get_ip_tuple_list () =
-        let loop ips tuples = match ips with
-          | ip1 :: ip2 :: tl -> (ip1, ip2) :: tuples
+      let get_ip_tuple_list l =
+        let rec loop ips tuples = match ips with
+          | ip1 :: ip2 :: tl -> loop tl ((ip1, ip2) :: tuples)
           | ip :: [] -> invalid_arg bad_len
           | [] -> List.rev tuples
         in


### PR DESCRIPTION
Without this patch, we only get the first tuple from the list.