### PR TITLE
add renewal logic; expose Dhcp_client_lwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ _ISC-licensed_ DHCP library implementation in OCaml.
 It provides three packages:
 
 - charrua-core: a library that handles wire traffic parsing and a server implementation
-- charrua-client: a client library, with a portable version and one using the MirageOS interfaces
+- charrua-client: a library for handling DHCP client state and messages
+- charrua-client-lwt: a DHCP client library with timeouts and network read/write
+- charrua-client-mirage: a MirageOS-compatible set of interfaces to charrua-client-lwt
 - charrua-unix: a Unix DHCP server implementation
 
 ### Charrua-core
@@ -44,9 +46,14 @@ southern South America.
 
 charrua-client is a DHCP client powered by [charrua-core](https://github.com/haesbaert/charrua-core).
 
-The base library exposes a simple state machine for acquiring a DHCP lease.
+The base library exposes a simple state machine in `Dhcp_client`
+for use in acquiring a DHCP lease.
 
-A sublibrary, `charrua-client.mirage`, exposes an additional functor for use
+`charrua-client-lwt` extends `charrua-client` with a functor `Dhcp_client_lwt`,
+using the provided modules for timing and networking logic,
+for convenient use by a program which might wish to implement a full client.
+
+`charrua-client-mirage` exposes an additional `Dhcp_client_mirage` for direct use
 with the [MirageOS library operating system](https://github.com/mirage/mirage).
 
 ### Charrua-unix Server

--- a/charrua-client-lwt.opam
+++ b/charrua-client-lwt.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name:         "charrua-client"
+name:         "charrua-client-lwt"
 maintainer:   ["Mindy Preston"]
 authors   :   ["Mindy Preston"]
 homepage:     "https://github.com/mirage/charrua-core"
@@ -21,8 +21,17 @@ depends: [
   "jbuilder" {>="1.0+beta9"}
   "ounit" {test}
   "alcotest"     {test}
-  "charrua-core" {>= "0.8"}
+  "charrua-core" {>= "0.4"}
+  "charrua-client"
   "cstruct" {>="3.0.2"}
   "ipaddr"
+  "rresult"
+  "mirage-random" {>= "1.0.0"}
+  "duration"
+  "logs"
+  "tcpip" {>= "3.0.0"}
+  "fmt"
+  "lwt"
+  "mirage-types-lwt" {>="3.0.0"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/charrua-client-mirage.opam
+++ b/charrua-client-mirage.opam
@@ -22,6 +22,7 @@ depends: [
   "ounit" {test}
   "alcotest"     {test}
   "charrua-core" {>= "0.4"}
+  "charrua-client-lwt"
   "charrua-client"
   "cstruct" {>="3.0.2"}
   "ipaddr"

--- a/charrua-client-mirage.opam
+++ b/charrua-client-mirage.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name:         "charrua-client"
+name:         "charrua-client-mirage"
 maintainer:   ["Mindy Preston"]
 authors   :   ["Mindy Preston"]
 homepage:     "https://github.com/mirage/charrua-core"
@@ -21,8 +21,17 @@ depends: [
   "jbuilder" {>="1.0+beta9"}
   "ounit" {test}
   "alcotest"     {test}
-  "charrua-core" {>= "0.8"}
+  "charrua-core" {>= "0.4"}
+  "charrua-client"
   "cstruct" {>="3.0.2"}
   "ipaddr"
+  "rresult"
+  "mirage-random" {>= "1.0.0"}
+  "duration"
+  "logs"
+  "tcpip" {>= "3.0.0"}
+  "fmt"
+  "lwt"
+  "mirage-types-lwt" {>="3.0.0"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/client/.merlin
+++ b/client/.merlin
@@ -1,6 +1,6 @@
 B ../_build/default/client
 B ../_build/default/lib
-FLG -w -40
+FLG -open Dhcp_client__ -w -40 -open Dhcp_client_lwt__ -w -40
 PKG bigarray
 PKG bytes
 PKG cstruct

--- a/client/dhcp_client.ml
+++ b/client/dhcp_client.ml
@@ -1,6 +1,14 @@
-type t = | Selecting of Dhcp_wire.pkt (* dhcpdiscover sent *)
-         | Requesting of (Dhcp_wire.pkt * Dhcp_wire.pkt) (* dhcpoffer input * dhcprequest sent *)
-         | Bound of Dhcp_wire.pkt (* dhcpack received *)
+type state  = | Selecting of Dhcp_wire.pkt (* dhcpdiscover sent *)
+              | Requesting of (Dhcp_wire.pkt * Dhcp_wire.pkt) (* dhcpoffer input * dhcprequest sent *)
+              | Bound of Dhcp_wire.pkt (* dhcpack received *)
+              | Renewing of (Dhcp_wire.pkt * Dhcp_wire.pkt) (* dhcpack received, dhcprequest sent *)
+type t = {
+  srcmac : Macaddr.t;
+  request_options : Dhcp_wire.option_code list;
+  xid : Cstruct.uint32;
+  state  : state;
+}
+
 type buffer = Cstruct.t
 
 (* some fields are constant *)
@@ -23,36 +31,37 @@ let default_requests =
 
 let pp fmt p =
   let pr = Dhcp_wire.pkt_to_string in
-  match p with
-  | Selecting pkt -> Format.fprintf fmt "SELECTING.  Generated %s" @@ pr pkt
-  | Requesting (received, sent) -> Format.fprintf fmt
-      "REQUESTING. Received %s, and generated response %s" (pr received) (pr sent)
-  | Bound pkt -> Format.fprintf fmt "BOUND.  Received %s" @@ pr pkt
+  let pp_state fmt = function
+    | Selecting pkt -> Format.fprintf fmt "SELECTING.  Generated %s" @@ pr pkt
+    | Requesting (received, sent) -> Format.fprintf fmt
+        "REQUESTING. Received %s, and generated response %s" (pr received) (pr sent)
+    | Bound pkt -> Format.fprintf fmt "BOUND.  Received %s" @@ pr pkt
+    | Renewing (ack, request) -> Format.fprintf fmt
+        "RENEWING.  Have lease %s, generated request %s" (pr ack) (pr request)
+  in
+  Format.fprintf fmt "%s: %a" (Macaddr.to_string p.srcmac) pp_state p.state
 
-let lease = function
-  | Bound dhcpack -> Some dhcpack
+let lease {state; _} = match state with
+  | Bound dhcpack | Renewing (dhcpack, _) -> Some dhcpack
   | Requesting _ | Selecting _ -> None
 
-let offer ~dhcpdiscover ~dhcpoffer () =
+let xid {state; _} =
   let open Dhcp_wire in
-  (* TODO: make sure the offer contains everything we expect before we accept it *)
-  let options = [
-    Message_type DHCPREQUEST;
-    Request_ip dhcpoffer.yiaddr;
-    Server_identifier dhcpoffer.siaddr;
-  ] in
-  let options =
-    match find_parameter_requests dhcpdiscover.options with
-    | None -> options (* if this is the case, the user explicitly requested it; honor that *)
-    | Some p -> (Parameter_requests p) :: options
-  in
-  let dhcprequest = Constants.({
+  match state with
+  | Selecting p -> p.xid
+  | Requesting (_i, o) -> o.xid
+  | Bound a -> a.xid
+  | Renewing (_i, o) -> o.xid
+
+let make_request ?(ciaddr = Ipaddr.V4.any) ~xid ~chaddr ~srcmac ~siaddr ~options () =
+  let open Dhcp_wire in
+  Constants.({
     htype; hlen; hops; sname; file;
-    xid = dhcpoffer.xid;
-    chaddr = dhcpdiscover.chaddr;
+    xid;
+    chaddr;
     srcport = Dhcp_wire.client_port;
     dstport = Dhcp_wire.server_port;
-    srcmac = dhcpdiscover.srcmac;
+    srcmac;
     srcip = Ipaddr.V4.any;
     (* destinations should still be broadcast,
      * even though we have the necessary information to send unicast,
@@ -65,44 +74,46 @@ let offer ~dhcpdiscover ~dhcpoffer () =
     options;
     secs = 0;
     flags = Broadcast;
-    ciaddr = Ipaddr.V4.any;
+    ciaddr;
     yiaddr = Ipaddr.V4.any;
-    siaddr = dhcpoffer.siaddr;
+    siaddr;
     giaddr = Ipaddr.V4.any;
-  }) in
-  Requesting (dhcpoffer, dhcprequest), Some (Dhcp_wire.buf_of_pkt dhcprequest)
+  })
 
-let respond_if t ~msgtype pkt f =
+let offer t ~xid ~chaddr ~server_ip ~request_ip ~offer_options =
   let open Dhcp_wire in
-  match find_message_type pkt.options with
-  | None -> (t, None)
-  | Some m when m = msgtype -> f ()
-  | Some _ -> (t, None)
+  (* TODO: make sure the offer contains everything we expect before we accept it *)
+  let options = [
+    Message_type DHCPREQUEST;
+    Request_ip request_ip;
+    Server_identifier server_ip;
+  ] in
+  let options =
+    match t.request_options with
+    | [] -> options (* if this is the case, the user explicitly requested it; honor that *)
+    | _::_ -> (Parameter_requests t.request_options) :: options
+  in
+  make_request ~xid ~chaddr ~srcmac:t.srcmac ~siaddr:server_ip ~options:options ()
 
-let input t buf =
-  let open Dhcp_wire in
-  match pkt_of_buf buf (Cstruct.len buf) with
-  | Error _ -> (t, None)
-  | Ok incoming ->
-    match t with
-    | Selecting dhcpdiscover when incoming.xid = dhcpdiscover.xid ->
-      respond_if t ~msgtype:DHCPOFFER incoming @@ offer ~dhcpdiscover ~dhcpoffer:incoming
-    | Requesting (_dhcpoffer, dhcprequest) when incoming.xid = dhcprequest.xid ->
-      respond_if t ~msgtype:DHCPACK incoming (fun () -> (Bound incoming , None))
-    | Selecting _ | Requesting _ | Bound _ -> (t, None)
-
-let create ?(requests = default_requests) mac =
+let create ?with_xid ?requests srcmac =
   let open Constants in
-  Stdlibrandom.initialize ();
-  let xid = Cstruct.BE.get_uint32 (Stdlibrandom.generate 4) 0 in
-  let pkt = Dhcp_wire.({
+  let open Dhcp_wire in
+  let xid = match with_xid with
+  | None -> Stdlibrandom.initialize (); Cstruct.BE.get_uint32 (Stdlibrandom.generate 4) 0
+  | Some xid -> xid
+  in
+  let requests = match requests with
+  | None | Some [] -> default_requests
+  | Some requests -> requests
+  in
+  let pkt = {
     htype; hlen; hops; sname; file;
-    srcmac = mac;
+    srcmac;
     dstmac = Macaddr.broadcast;
     srcip = Ipaddr.V4.any;
     dstip = Ipaddr.V4.broadcast;
-    srcport = Dhcp_wire.client_port;
-    dstport = Dhcp_wire.server_port;
+    srcport = client_port;
+    dstport = server_port;
     op = BOOTREQUEST;
     xid;
     secs = 0;
@@ -111,10 +122,61 @@ let create ?(requests = default_requests) mac =
     yiaddr = Ipaddr.V4.any;
     siaddr = Ipaddr.V4.any;
     giaddr = Ipaddr.V4.any;
-    chaddr = mac;
-    options = Dhcp_wire.([
+    chaddr = srcmac;
+    options = [
       Message_type DHCPDISCOVER;
       Parameter_requests requests;
-    ]);
-  }) in
-  (Selecting pkt), (Dhcp_wire.buf_of_pkt pkt)
+    ];
+  } in
+  {srcmac; xid; request_options = requests; state = Selecting pkt},
+    Dhcp_wire.buf_of_pkt pkt
+
+let input t buf =
+  let open Dhcp_wire in
+  match pkt_of_buf buf (Cstruct.len buf) with
+  | Error _ -> `Noop
+  | Ok incoming ->
+    if compare incoming.xid (xid t) = 0 then begin
+    match find_message_type incoming.options, t.state with
+    | None, _ -> `Noop
+    | Some DHCPOFFER, Selecting dhcpdiscover ->
+        let dhcprequest = offer t ~server_ip:incoming.siaddr
+                          ~request_ip:incoming.yiaddr
+                          ~offer_options:incoming.options
+                          ~xid:dhcpdiscover.xid
+                          ~chaddr:dhcpdiscover.chaddr in
+        `Response ({t with state = Requesting (incoming, dhcprequest)},
+          (Dhcp_wire.buf_of_pkt dhcprequest))
+    | Some DHCPOFFER, _ -> (* DHCPOFFER is irrelevant when we're not selecting *)
+      `Noop
+    | Some DHCPACK, Renewing _
+    | Some DHCPACK, Requesting _ -> `New_lease ({t with state = Bound incoming}, incoming)
+    | Some DHCPNAK, Requesting _ | Some DHCPNAK, Renewing _ ->
+      `Response (create ~with_xid:t.xid ~requests:t.request_options t.srcmac)
+    | Some DHCPACK, Selecting _ (* too soon *)
+    | Some DHCPACK, Bound _ -> (* too late *)
+      `Noop
+    | Some DHCPDISCOVER, _ | Some DHCPDECLINE, _ | Some DHCPRELEASE, _
+    | Some DHCPINFORM, _ | Some DHCPREQUEST, _ ->
+      (* we don't need to care about these client messages *)
+      `Noop
+    | Some DHCPNAK, Selecting  _| Some DHCPNAK, Bound _ -> `Noop (* irrelevant *)
+    | Some DHCPLEASEQUERY, _ | Some DHCPLEASEUNASSIGNED, _
+    | Some DHCPLEASEUNKNOWN, _ | Some DHCPLEASEACTIVE, _
+    | Some DHCPBULKLEASEQUERY, _ | Some DHCPLEASEQUERYDONE, _ ->
+      (* these messages are for relay agents to extract information from servers;
+       * our client does not care about them and shouldn't reply *)
+      `Noop
+    | Some DHCPFORCERENEW, _ -> `Noop (* unsupported *)
+    end else `Noop
+
+let renew t = match t.state with
+  | Selecting _ | Requesting _ -> `Noop
+  | Renewing (_lease, request) -> `Response (t, Dhcp_wire.buf_of_pkt request)
+  | Bound lease ->
+    let open Dhcp_wire in
+    let request = offer t ~xid:lease.xid ~chaddr:lease.chaddr
+      ~server_ip:lease.siaddr ~request_ip:lease.yiaddr
+      ~offer_options:lease.options in
+    let state = Renewing (lease, request) in
+    `Response ({t with state = state}, (Dhcp_wire.buf_of_pkt request))

--- a/client/dhcp_client.mli
+++ b/client/dhcp_client.mli
@@ -4,18 +4,23 @@ type buffer = Cstruct.t
 
 val pp : Format.formatter -> t -> unit
 
-val create : ?requests : Dhcp_wire.option_code list -> Macaddr.t -> (t * buffer)
+val create : ?with_xid : Cstruct.uint32 -> ?requests : Dhcp_wire.option_code list -> Macaddr.t -> (t * buffer)
 (** [create mac] returns a pair of [t, buffer].  [t] represents the current 
  * state of the client in the lease transaction, and [buffer] is the suggested
- * next packet the caller should take to progress toward accepting a lease. *)
+ * next packet the caller should take to progress toward accepting a lease.
+ * The optional argument [with_xid] allows the caller to specify a transaction ID
+ * to use for the lease attempt.
+ * [requests] is a list of option codes which the client should ask for in its
+ * attempt to get a DHCP lease.  If [requests] is not given, we'll make an educated
+ * guess rather than requesting nothing.
+ *)
 
-val input : t -> buffer -> (t * buffer option)
+val input : t -> buffer -> [`Response of (t * buffer) | `New_lease of (t * Dhcp_wire.pkt) | `Noop ]
 (** [input t buf] attempts to advance the state of [t]
- * with the contents of [buf].  If [buf] is valid input to the
- * DHCP input parser and the information within is useful given the
- * current state of [t], the state will be advanced and a new [Some packet]
- * suggested for the caller to send.
- * If not, the previous [t] will be returned with [None]. *)
+ * with the contents of [buf].  If [buf] is invalid or not useful given
+ * the current state of [t], [`Noop] is returned indicating no action should be taken.
+ * Otherwise, either a [`Response] will be suggested along with a [t] whose state has been advanced,
+ * or a [`New_lease] will be returned along with a [t] whose state has been advanced. *)
 
 val lease : t -> Dhcp_wire.pkt option
 (** [lease t] will return [Some lease] if [t] has succeeded in
@@ -23,6 +28,11 @@ val lease : t -> Dhcp_wire.pkt option
  * Note that the library has no sense of the passage of time, so expiration
  * is not considered; there is no guarantee that [Some lease] is still
  * valid on the network.  The caller is responsible for keeping track of
- * time time at which the lease was obtained, and renewing the lease when
+ * the time at which the lease was obtained, and renewing the lease when
  * necessary.
  * If [t] hasn't yet completed a lease transaction, [None] will be returned. *)
+
+val renew : t -> [`Response of (t * buffer) | `Noop]
+(** [renew t] returns either a [`Response] with the next state and suggested action
+ * of the client attempting to renew [t]'s lease,
+ * or [`Noop] if [t] does not have a lease and therefore can't be renewed. *)

--- a/client/dhcp_client_lwt.ml
+++ b/client/dhcp_client_lwt.ml
@@ -1,0 +1,90 @@
+let src = Logs.Src.create "dhcp_client_lwt"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Make(Time : Mirage_time_lwt.S) (Net : Mirage_net_lwt.S) = struct
+  open Lwt.Infix
+
+  type lease = Dhcp_wire.pkt
+
+  type t = lease Lwt_stream.t
+
+  let connect ?(with_xid)
+              ?(requests : Dhcp_wire.option_code list option) net =
+    (* listener needs to occasionally check to see whether the state has advanced,
+     * and if not, start a new attempt at a lease transaction *)
+    let sleep_interval = Duration.of_sec 3 in
+
+    let (client, dhcpdiscover) = Dhcp_client.create ?with_xid ?requests (Net.mac net) in
+    let c = ref client in
+
+    let rec renew c t =
+      Time.sleep_ns @@ Duration.of_sec t >>= fun () ->
+      match Dhcp_client.renew c with
+      | `Noop -> Log.debug (fun f -> f "Can't renew this lease; won't try");  Lwt.return_unit
+      | `Response (c, buf) ->
+        Log.debug (fun f -> f "attempted to renew lease: %a" Dhcp_client.pp c);
+        Net.write net buf >>= function
+          | Error e ->
+            Log.err (fun f -> f "Failed to write lease renewal request: %a" Net.pp_error e);
+            Lwt.return_unit
+          | Ok () ->
+            renew c t (* ideally t would come from the new lease... *)
+    in
+    let rec get_lease push dhcpdiscover =
+      Log.debug (fun f -> f "Sending DHCPDISCOVER...");
+      Net.write net dhcpdiscover >>= function
+      | Error e ->
+        Log.err (fun f -> f "Failed to write initial lease discovery request: %a" Net.pp_error e);
+        Lwt.return_unit
+      | Ok () ->
+        Time.sleep_ns sleep_interval >>= fun () ->
+        let (client, dhcpdiscover) = Dhcp_client.create ?requests (Net.mac net) in
+        c := client;
+        Log.info (fun f -> f "Timeout expired without a usable lease!  Starting over...");
+        Log.debug (fun f -> f "New lease attempt: %a" Dhcp_client.pp !c);
+        get_lease push dhcpdiscover
+    in
+    let listen push () =
+      Net.listen net (fun buf ->
+        match Dhcp_client.input !c buf with
+        | `Noop ->
+          Log.debug (fun f -> f "No action! State is %a" Dhcp_client.pp !c);
+          Lwt.return_unit
+        | `Response (s, action) -> begin
+          Net.write net action >>= function
+          | Error e ->
+            Log.err (fun f -> f "Failed to write lease transaction response: %a" Net.pp_error e);
+            Lwt.return_unit
+          | Ok () ->
+            Log.debug (fun f -> f "State advanced! Now %a" Dhcp_client.pp s);
+            c := s;
+            Lwt.return_unit
+        end
+        | `New_lease (s, l) ->
+          let open Dhcp_wire in
+          (* a lease is obtained! Note it, and replace the current listener *)
+          Log.info (fun f -> f "Lease obtained! IP: %a, routers: %a"
+          Ipaddr.V4.pp_hum l.yiaddr
+          (Fmt.list Ipaddr.V4.pp_hum) (collect_routers l.options));
+          push @@ Some l;
+          c := s;
+          Time.sleep_ns @@ Duration.of_sec 1800 >>= fun () ->
+          renew !c 1800
+      )
+    in
+    let lease_wrapper (push : Dhcp_wire.pkt option -> unit) () =
+      Lwt.pick [
+        (listen push () >|= function
+          | Error _ | Ok () -> push None (* if canceled, the stream should end *)
+        );
+        get_lease push dhcpdiscover; (* will terminate once a lease is obtained *)
+      ]
+    in
+    let (s, push) = Lwt_stream.create () in
+    let hook = function
+      | e -> raise e
+    in
+    Lwt.async_exception_hook := hook;
+    Lwt.async (fun () -> lease_wrapper push ());
+    Lwt.return s
+end

--- a/client/dhcp_client_lwt.ml
+++ b/client/dhcp_client_lwt.ml
@@ -13,7 +13,7 @@ module Make(Time : Mirage_time_lwt.S) (Net : Mirage_net_lwt.S) = struct
               ?(requests : Dhcp_wire.option_code list option) net =
     (* listener needs to occasionally check to see whether the state has advanced,
      * and if not, start a new attempt at a lease transaction *)
-    let sleep_interval = Duration.of_sec 3 in
+    let sleep_interval = Duration.of_sec 4 in
 
     let (client, dhcpdiscover) = Dhcp_client.create ?with_xid ?requests (Net.mac net) in
     let c = ref client in

--- a/client/dhcp_client_lwt.mli
+++ b/client/dhcp_client_lwt.mli
@@ -1,0 +1,6 @@
+module Make(Time : Mirage_time_lwt.S) (Net : Mirage_net_lwt.S) : sig
+  type lease = Dhcp_wire.pkt
+
+  type t = lease Lwt_stream.t
+  val connect : ?with_xid : Cstruct.uint32 -> ?requests:Dhcp_wire.option_code list -> Net.t -> t Lwt.t
+end

--- a/client/dhcp_client_lwt.mli
+++ b/client/dhcp_client_lwt.mli
@@ -2,5 +2,14 @@ module Make(Time : Mirage_time_lwt.S) (Net : Mirage_net_lwt.S) : sig
   type lease = Dhcp_wire.pkt
 
   type t = lease Lwt_stream.t
-  val connect : ?with_xid : Cstruct.uint32 -> ?requests:Dhcp_wire.option_code list -> Net.t -> t Lwt.t
+
+  val connect : ?renew:bool -> ?with_xid : Cstruct.uint32 ->
+    ?requests:Dhcp_wire.option_code list -> Net.t -> t Lwt.t
+  (** [connect renew with_xid requests net] starts a DHCP client communicating
+      over the network interface [net].  The client will attempt to get a DHCP
+      lease at least once, and will return any leases obtained in the stream
+      returned by [connect].  If [renew] is true, which it is by default,
+      the client will attempt to renew the lease according to the logic in
+      RFC2131.  If [renew] is false, the client will cancel its listener and end
+      the stream once the first lease has been obtained. *)
 end

--- a/client/jbuild
+++ b/client/jbuild
@@ -4,3 +4,8 @@
   (public_name charrua-client)
   (libraries   (charrua-core.wire))
 ))
+(library
+ ((name        dhcp_client_lwt)
+  (public_name charrua-client-lwt)
+  (libraries   (charrua-core.wire lwt))
+))

--- a/client/mirage/dhcp_client_mirage.ml
+++ b/client/mirage/dhcp_client_mirage.ml
@@ -27,7 +27,7 @@ module Make(Time : Mirage_types_lwt.TIME) (Net : Mirage_types_lwt.NETWORK) = str
 
   let connect ?(requests : Dhcp_wire.option_code list option) net =
     let module Lwt_client = Dhcp_client_lwt.Make(Time)(Net) in
-    Lwt_client.connect ?requests net >>= fun lease_stream ->
+    Lwt_client.connect ~renew:false ?requests net >>= fun lease_stream ->
     Lwt.return @@ Lwt_stream.filter_map config_of_lease lease_stream
 
 end

--- a/client/mirage/dhcp_client_mirage.ml
+++ b/client/mirage/dhcp_client_mirage.ml
@@ -1,72 +1,33 @@
-let ipv4_config_of_lease lease : Mirage_protocols_lwt.ipv4_config option =
+let src = Logs.Src.create "dhcp_client_mirage"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let config_of_lease lease : Mirage_protocols_lwt.ipv4_config option =
   let open Dhcp_wire in
   (* ipv4_config expects a single IP address and the information
    * needed to construct a prefix.  It can optionally use one router. *)
   let address = lease.yiaddr in
   match Dhcp_wire.find_subnet_mask lease.options with
-  | None -> None
+  | None ->
+    Log.info (fun f -> f "Lease obtained with no subnet mask; discarding it");
+    Log.debug (fun f -> f "Unusable lease: %s" @@ Dhcp_wire.pkt_to_string lease);
+    None
   | Some subnet ->
     let network = Ipaddr.V4.Prefix.of_netmask subnet address in
     let valid_routers = Dhcp_wire.collect_routers lease.options in
     match valid_routers with
-    | [] -> Some (Mirage_protocols_lwt.{ address; network; gateway = None })
+    | [] -> Some Mirage_protocols_lwt.{ address; network; gateway = None }
     | hd::_ ->
-      Some (Mirage_protocols_lwt.{ address; network; gateway = (Some hd) })
-
-let src = Logs.Src.create "dhcp_client"
-module Log = (val Logs.src_log src : Logs.LOG)
+      Some Mirage_protocols_lwt.{ address; network; gateway = (Some hd) }
 
 module Make(Time : Mirage_types_lwt.TIME) (Net : Mirage_types_lwt.NETWORK) = struct
   open Lwt.Infix
+  open Mirage_protocols_lwt
 
-  type t = Mirage_protocols_lwt.ipv4_config Lwt_stream.t
-
-  let usable_config_of_lease = function
-  | None -> None
-  | Some lease -> ipv4_config_of_lease lease
+  type t = ipv4_config Lwt_stream.t
 
   let connect ?(requests : Dhcp_wire.option_code list option) net =
-    (* listener needs to occasionally check to see whether the state has advanced,
-     * and if not, start a new attempt at a lease transaction *)
-    let sleep_interval = Duration.of_sec 5 in
-
-    let (client, dhcpdiscover) = Dhcp_client.create ?requests (Net.mac net) in
-    let c = ref client in
-
-    let rec repeater dhcpdiscover =
-      Log.debug (fun f -> f "Sending DHCPDISCOVER...");
-      Net.write net dhcpdiscover >|= Rresult.R.get_ok >>= fun () ->
-      Time.sleep_ns sleep_interval >>= fun () ->
-      match usable_config_of_lease (Dhcp_client.lease !c) with
-      | Some lease ->
-        Log.info (fun f -> f "Lease obtained! IP %a network %a gateway %a"
-          Ipaddr.V4.pp_hum lease.address Ipaddr.V4.Prefix.pp_hum lease.network
-          (Fmt.option Ipaddr.V4.pp_hum) lease.gateway);
-          Lwt.return (Some lease)
-      | None ->
-        let (client, dhcpdiscover) = Dhcp_client.create ?requests (Net.mac net) in
-        c := client;
-        Log.info (fun f -> f "Timeout expired without a usable lease!  Starting over...");
-        Log.debug (fun f -> f "New lease attempt: %a" Dhcp_client.pp !c);
-        repeater dhcpdiscover 
-    in
-    let listen () =
-      Net.listen net (fun buf ->
-        match Dhcp_client.input !c buf with
-        | (s, Some action) -> Net.write net action >|=
-          Rresult.R.get_ok >>= fun () ->
-          Log.debug (fun f -> f "State advanced! Now %a" Dhcp_client.pp s);
-          c := s; Lwt.return_unit
-        | (s, None) ->
-          Log.debug (fun f -> f "No action! State is %a" Dhcp_client.pp s);
-          c := s; Lwt.return_unit
-      ) >|= Rresult.R.get_ok
-    in
-    let get_lease () =
-      Lwt.pick [ (listen () >>= fun () -> Lwt.return None);
-               repeater dhcpdiscover; ]
-    in
-    let s = Lwt_stream.from get_lease in
-    Lwt.return s
+    let module Lwt_client = Dhcp_client_lwt.Make(Time)(Net) in
+    Lwt_client.connect ?requests net >>= fun lease_stream ->
+    Lwt.return @@ Lwt_stream.filter_map config_of_lease lease_stream
 
 end

--- a/client/mirage/dhcp_client_mirage.mli
+++ b/client/mirage/dhcp_client_mirage.mli
@@ -1,13 +1,3 @@
-val ipv4_config_of_lease :
-  Dhcp_wire.pkt -> Mirage_protocols_lwt.ipv4_config option
-(** [ipv4_config_of_lease pkt] checks whether [pkt] represents
- *  a valid IPv4 configuration (regardless of the time at which
- *  [pkt] was sent and the time given for its validity).  If [pkt]
- *  looks usable, [Some config] is returned representing the values
- *  therein.  For [pkt] representing anything other than a complete
- *  lease containing the minimum information needed for an
- *  IPv4 configuration, [ipv4_config_of_lease pkt] returns [None]. *)
-
 module Make(Time : Mirage_types_lwt.TIME) (Network : Mirage_types_lwt.NETWORK) : sig
   type t = Mirage_protocols_lwt.ipv4_config Lwt_stream.t
   val connect : ?requests:Dhcp_wire.option_code list

--- a/client/mirage/jbuild
+++ b/client/mirage/jbuild
@@ -1,6 +1,6 @@
 (jbuild_version 1)
 (library
  ((name        dhcp_client_mirage)
-  (public_name charrua-client.mirage)
-  (libraries   (charrua-client mirage-types-lwt))
+  (public_name charrua-client-mirage)
+  (libraries   (charrua-client-lwt mirage-types-lwt))
   (wrapped false)))

--- a/test/client/jbuild
+++ b/test/client/jbuild
@@ -1,7 +1,8 @@
 (jbuild_version 1)
 (executables
  ((names (test_client))
-  (libraries (cstruct-unix alcotest charrua-client charrua-core.server))))
+  (libraries (cstruct-unix alcotest charrua-client charrua-core.server)))
+)
 
 (alias
  ((name    runtest)

--- a/test/client/lwt/jbuild
+++ b/test/client/lwt/jbuild
@@ -1,0 +1,11 @@
+(jbuild_version 1)
+(executable
+ ((name test_client_lwt)
+  (libraries (cstruct-unix alcotest charrua-client-lwt charrua-core.server lwt.unix mirage-random)))
+)
+
+(alias
+ ((name    runtest)
+  (package charrua-client)
+  (deps    (test_client_lwt.exe))
+  (action  (run ${<}))))

--- a/test/client/lwt/test_client_lwt.ml
+++ b/test/client/lwt/test_client_lwt.ml
@@ -1,0 +1,62 @@
+open Lwt.Infix
+
+(* additional tests for time- and network-dependent code *)
+
+module No_time = struct
+  type 'a io = 'a Lwt.t
+  let sleep_ns n = Format.printf "Ignoring request to wait %f seconds\n" @@ Duration.to_f n;
+    Lwt_main.yield ()
+end
+
+module No_net = struct
+  type error = Mirage_device.error
+  let pp_error = Mirage_device.pp_error
+  type stats = Mirage_net.stats
+  type 'a io = 'a Lwt.t
+  type macaddr = Macaddr.t
+  type page_aligned_buffer = Io_page.t
+  type buffer = Cstruct.t
+  type t = { mac : Macaddr.t; mutable packets : Cstruct.t list }
+  let disconnect _ = Lwt.return_unit
+  let writev t l =
+    t.packets <- t.packets @ l;
+    Lwt.return_ok ()
+  let write t p =
+    t.packets <- p :: t.packets;
+    Lwt.return_ok ()
+  let listen _ _ = Lwt.return_ok ()
+  let mac t = t.mac
+  let reset_stats_counters _ = ()
+  let get_stats_counters _ = {
+    Mirage_net.rx_bytes = 0L;
+    tx_bytes = 0L;
+    rx_pkts = 0l;
+    tx_pkts = 0l;
+  }
+  let connect ~mac () = { packets = []; mac }
+  let get_packets t = t.packets
+end
+
+let keep_trying () =
+  Lwt_main.run @@ (
+    let module Client = Dhcp_client_lwt.Make(No_time)(No_net) in
+    let net = No_net.connect ~mac:(Macaddr.of_string_exn "c0:ff:ee:c0:ff:ee") () in
+    let test =
+      Client.connect net >>= fun lease_stream ->
+      Lwt_stream.get lease_stream >|= function
+      | Some _ -> Alcotest.fail "got a lease from a nonfunction network somehow"
+      | None -> ()
+    in
+    Lwt.pick [
+      test;
+      Lwt_main.yield () >>= function () ->
+      (Alcotest.(check bool) "sent >1 packet" true (List.length (No_net.get_packets net) > 1); Lwt.return_unit)
+    ]
+  )
+
+let () =
+  Alcotest.run "lwt client tests" [
+    "timeouts", [
+       "more than one dhcpdiscover is sent", `Quick, keep_trying;
+    ]
+  ]

--- a/test/client/lwt/test_client_lwt.ml
+++ b/test/client/lwt/test_client_lwt.ml
@@ -42,9 +42,8 @@ let keep_trying () =
     let module Client = Dhcp_client_lwt.Make(No_time)(No_net) in
     let net = No_net.connect ~mac:(Macaddr.of_string_exn "c0:ff:ee:c0:ff:ee") () in
     let test =
-      Client.connect net >>= fun lease_stream ->
-      Lwt_stream.get lease_stream >|= function
-      | Some _ -> Alcotest.fail "got a lease from a nonfunction network somehow"
+      Client.connect net >>= Lwt_stream.get >|= function
+      | Some _ -> Alcotest.fail "got a lease from a nonfunctioning network somehow"
       | None -> ()
     in
     Lwt.pick [


### PR DESCRIPTION
Previously, the only exposed modules were a pure `Dhcp_client` and a
module for use in Mirage, implementing the client timing logic and
exposing only an `ipv4_config`.

This changeset exposes a `Dhcp_client_lwt` module which
handles timing logic and exposes the full lease information once the
lease is obtained, for use in a wider variety of contexts (e.g., a
client which also sets network parameters according to the lease in a
traditional OS).  

This changeset also adds packages charrua-client-lwt and charrua-client-mirage.
It removes some dependencies from charrua-client.

Since the client may now be used in a context where proper renewal is
possible, add logic and tests for handling it properly.
As part of this change, Dhcp_client.input now returns a polyvar
rather than an option, indicating whether the message has a new lease.