### PR TITLE
Re-implement UDP checksum on input.

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -70,6 +70,8 @@ let cons_if p v tl = if p then v :: tl else tl
 let cons_if_some v tl = match v with Some v -> v :: tl | None -> tl
 let cons_if_some_f v fnr tl = match v with Some x -> fnr x :: tl | None -> tl
 
+let guard p e = if p then Result.Ok () else Result.Error e
+
 let addr_in_range addr range =
   let low_ip, high_ip = range in
   let low_32 = Ipaddr.V4.to_int32 low_ip in


### PR DESCRIPTION
The unmarshal function doesn't verify checksum, so we have to do it ourselves.
There doesn't seem to be a simple API for verifying IPV4 header checksum in Tcpip.

Can anyone clarify why this is not done by the unmarshal function ? 
This seems incredibly error prone, and we should not give an option for the user to keep a packet if the checksum is incorrect imho.