### PR TITLE
Fix charrua-client-lwt build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ env:
   global:
   - PACKAGE="charrua-core"
   - TESTS=true
-  - PINS="charrua-client:. charrua-unix:."
-  - DEPOPTS="charrua-client charrua-unix"
+  - PINS="charrua-client:. charrua-unix:. charrua-client:. charrua-client-lwt:. charrua-client-mirage:."
   matrix:
   - DISTRO="alpine-3.5" OCAML_VERSION="4.03.0"
   - DISTRO="centos-6" OCAML_VERSION="4.04.1"

--- a/charrua-client-lwt.opam
+++ b/charrua-client-lwt.opam
@@ -26,6 +26,7 @@ depends: [
   "rresult"
   "mirage-random" {>= "1.0.0"}
   "duration"
+  "mirage-time-lwt"
   "logs"
   "tcpip" {>= "3.0.0"}
   "fmt"

--- a/client/lwt/jbuild
+++ b/client/lwt/jbuild
@@ -4,4 +4,5 @@
  ((name        dhcp_client_lwt)
   (public_name charrua-client-lwt)
   (modules     (dhcp_client_lwt))
-  (libraries   (charrua-core.wire lwt charrua-client))))
+  (libraries   (charrua-core.wire lwt charrua-client
+                mirage-time-lwt duration))))

--- a/test/client/jbuild
+++ b/test/client/jbuild
@@ -2,7 +2,7 @@
 
 (executables
  ((names (test_client))
-  (libraries (cstruct-unix alcotest charrua-client charrua-core.server))))
+  (libraries (cstruct-unix alcotest charrua-client charrua-core.server tcpip.unix))))
 
 (alias
  ((name    runtest)

--- a/test/jbuild
+++ b/test/jbuild
@@ -3,7 +3,7 @@
 (executables
  ((names (test))
   (preprocess (pps (ppx_cstruct)))
-  (libraries (cstruct-unix io-page.unix charrua-core.server))))
+  (libraries (cstruct-unix io-page.unix charrua-core.server tcpip.unix))))
 
 (alias
  ((name    runtest)


### PR DESCRIPTION
This adds missing dependencies and hopefully re-enables CI for the `charrua-client-{lwt,mirage}` packages.