### PR TITLE
charrua-client-lwt: remove undefined exception behaviour

### DIFF
--- a/client/lwt/dhcp_client_lwt.ml
+++ b/client/lwt/dhcp_client_lwt.ml
@@ -90,10 +90,6 @@ module Make(Time : Mirage_time_lwt.S) (Net : Mirage_net_lwt.S) = struct
       ]
     in
     let (s, push) = Lwt_stream.create () in
-    let hook = function
-      | e -> raise e
-    in
-    Lwt.async_exception_hook := hook;
     Lwt.async (fun () -> lease_wrapper push ());
     Lwt.return s
 end


### PR DESCRIPTION
The [Lwt.async_exception_hook documentation](http://ocsigen.org/lwt/3.1.0/api/Lwt#VALasync_exception_hook) says:

> The behavior is undefined if this function raise an exception.

This patch removes the hook which raised an exception.

I think the `Lwt.async_exception_hook` should be treated like a Unix signal handler: left to the application author to configure and not used by libraries (which may have clashing requirements)

Signed-off-by: David Scott <dave@recoil.org>