### PR TITLE
set name in pkg.ml

### DIFF
--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,2 +1,7 @@
 #use "topfind"
-#require "topkg-jbuilder.auto"
+#require "topkg-jbuilder"
+
+open Topkg
+
+let () =
+  Topkg_jbuilder.describe ~name:"charrua-core" ()


### PR DESCRIPTION
Before this change, trying to `topkg distrib` fails:

```
 topkg distrib --dist-version v0.9 --dist-name charrua-core
pkg.ml: [ERROR] cannot determine name automatically.
You must pass a [name] argument to [Topkg_jbuilder.describe] in pkg/pkg.ml
pkg.ml: [ERROR] No package description found. A syntax error may have occured
                or did you forget to call Topkg.Pkg.describe ?
topkg: [ERROR] run ['ocaml' 'pkg/pkg.ml' 'ipc' 'warning'
               '/tmp/topkgbb0031topkg' 'pkg']: exited with 1
               Failed to load package description pkg/pkg.ml
```

I think this must be user error since the last release was done somehow without this change, but the readme at https://github.com/diml/topkg-jbuilder seems to imply that it would be needed. 