### PR TITLE
charrua-client uses Stdlibrandom from mirage-random (<= 1.1.0) directly

### DIFF
--- a/charrua-client.opam
+++ b/charrua-client.opam
@@ -24,5 +24,6 @@ depends: [
   "charrua-core" {>= "0.10"}
   "cstruct" {>="3.0.2"}
   "ipaddr"
+  "mirage-random" {>= "1.0.0" & <= "1.1.0"}
 ]
 available: [ocaml-version >= "4.03.0"]


### PR DESCRIPTION
the opam + jbuild file do not refer to mirage-random, but the code (`client/dhcp_client.ml`) uses `Stdlibrandom` directly.  would it be ok to pass `rng:(int -> Cstruct.t)` to `create`!?