### PR TITLE
rework usage of randomness in Dhcp_client

### DIFF
--- a/charrua-client-lwt.opam
+++ b/charrua-client-lwt.opam
@@ -1,24 +1,24 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name:         "charrua-client-lwt"
 maintainer:   ["Mindy Preston"]
 authors   :   ["Mindy Preston"]
 homepage:     "https://github.com/mirage/charrua-core"
 bug-reports:  "https://github.com/mirage/charrua-core/issues"
-dev-repo:     "https://github.com/mirage/charrua-core.git"
+dev-repo:     "git+https://github.com/mirage/charrua-core.git"
 tags:         [ "org:mirage"]
 doc:          "https://docs.mirage.io"
 
 build: [
   ["jbuilder" "subst" "-n" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-
-build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 
 depends: [
   "jbuilder" {build & >= "1.0+beta9"}
-  "alcotest"     {test}
-  "cstruct-unix" {test}
+  "ocaml" {>= "4.03.0"}
+  "alcotest"     {with-test}
+  "cstruct-unix" {with-test}
   "charrua-core" {>= "0.10"}
   "charrua-client" {>= "0.10"}
   "cstruct" {>="3.0.2"}
@@ -33,4 +33,9 @@ depends: [
   "lwt"
   "mirage-types-lwt" {>="3.0.0"}
 ]
-available: [ocaml-version >= "4.03.0"]
+synopsis: "A DHCP client using lwt as effectful layer"
+description: """
+`charrua-client-lwt` extends `charrua-client` with a functor `Dhcp_client_lwt`,
+using the provided modules for timing and networking logic,
+for convenient use by a program which might wish to implement a full client.
+"""

--- a/charrua-client-mirage.opam
+++ b/charrua-client-mirage.opam
@@ -1,10 +1,10 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name:         "charrua-client-mirage"
 maintainer:   ["Mindy Preston"]
 authors   :   ["Mindy Preston"]
 homepage:     "https://github.com/mirage/charrua-core"
 bug-reports:  "https://github.com/mirage/charrua-core/issues"
-dev-repo:     "https://github.com/mirage/charrua-core.git"
+dev-repo:     "git+https://github.com/mirage/charrua-core.git"
 tags:         [ "org:mirage"]
 doc:          "https://docs.mirage.io"
 
@@ -13,11 +13,9 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 
-build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
-
 depends: [
   "jbuilder" {build & >= "1.0+beta9"}
-  "alcotest"     {test}
+  "ocaml" {>= "4.03.0"}
   "charrua-core" {>= "0.10"}
   "charrua-client-lwt" {>= "0.10"}
   "charrua-client" {>= "0.10"}
@@ -33,4 +31,8 @@ depends: [
   "lwt"
   "mirage-types-lwt" {>="3.0.0"}
 ]
-available: [ocaml-version >= "4.03.0"]
+synopsis: "A DHCP client for MirageOS"
+description: """
+`charrua-client-mirage` exposes an additional `Dhcp_client_mirage` for direct use
+with the [MirageOS library operating system](https://github.com/mirage/mirage).
+"""

--- a/charrua-client.opam
+++ b/charrua-client.opam
@@ -21,6 +21,7 @@ depends: [
   "jbuilder" {build & >= "1.0+beta9"}
   "alcotest"     {test}
   "cstruct-unix" {test}
+  "mirage-random-test" {test}
   "charrua-core" {>= "0.10"}
   "cstruct" {>="3.0.2"}
   "ipaddr"

--- a/charrua-client.opam
+++ b/charrua-client.opam
@@ -1,29 +1,33 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name:         "charrua-client"
 maintainer:   ["Mindy Preston"]
 authors   :   ["Mindy Preston"]
 homepage:     "https://github.com/mirage/charrua-core"
 bug-reports:  "https://github.com/mirage/charrua-core/issues"
-dev-repo:     "https://github.com/mirage/charrua-core.git"
+dev-repo:     "git+https://github.com/mirage/charrua-core.git"
 tags:         [ "org:mirage"]
 doc:          "https://docs.mirage.io"
 
 build: [
   [ "jbuilder" "subst" "-n" name ] {pinned}
   [ "jbuilder" "build" "-p" name "-j" jobs ]
-]
-
-build-test: [
-  [ "jbuilder" "runtest" "-p" name "-j" jobs ]
+  [ "jbuilder" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 
 depends: [
   "jbuilder" {build & >= "1.0+beta9"}
-  "alcotest"     {test}
-  "cstruct-unix" {test}
-  "mirage-random-test" {test}
+  "ocaml" {>= "4.03.0"}
+  "alcotest"     {with-test}
+  "cstruct-unix" {with-test}
+  "mirage-random-test" {with-test}
   "charrua-core" {>= "0.10"}
   "cstruct" {>="3.0.2"}
   "ipaddr"
 ]
-available: [ocaml-version >= "4.03.0"]
+synopsis: "DHCP client implementation"
+description: """
+charrua-client is a DHCP client powered by [charrua-core](https://github.com/haesbaert/charrua-core).
+
+The base library exposes a simple state machine in `Dhcp_client`
+for use in acquiring a DHCP lease.
+"""

--- a/charrua-core.opam
+++ b/charrua-core.opam
@@ -1,22 +1,17 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name: "charrua-core"
 maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
 authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
 license: "ISC"
 homepage: "https://github.com/mirage/charrua-core"
 bug-reports: "https://github.com/mirage/charrua-core/issues"
-dev-repo: "https://github.com/mirage/charrua-core.git"
+dev-repo: "git+https://github.com/mirage/charrua-core.git"
 doc: "https://mirage.github.io/charrua-core/api"
-
-available: [ocaml-version >= "4.03" & opam-version >= "1.2"]
 
 build: [
   ["jbuilder" "subst" "-n" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-]
-
-build-test: [
-  ["jbuilder" "runtest" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
@@ -24,11 +19,40 @@ depends: [
   "ppx_sexp_conv" {build}
   "ppx_cstruct"   {build}
   "menhir"        {build}
+  "ocaml"         {>= "4.0.3"}
   "cstruct"       {>= "3.0.1"}
   "sexplib"
   "ipaddr"        {>= "2.5.0"}
   "tcpip"         {>= "3.2.0"}
   "rresult"
-  "io-page-unix"  {test}
-  "cstruct-unix"  {test}
+  "io-page-unix"  {with-test}
+  "cstruct-unix"  {with-test}
 ]
+synopsis: "DHCP wire frame encoder and decoder"
+description: """
+Charrua-core consists of two modules, a `Dhcp_wire` responsible for parsing and
+constructing DHCP messages and a `Dhcp_server` module used for constructing DHCP
+servers.
+
+You can browse the API for [charrua-core](http://www.github.com/mirage/charrua-core) at
+http://mirage.github.io/charrua-core/api
+
+[dhcp](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp)
+is a Mirage DHCP unikernel server based on charrua-core, included as a part of the MirageOS unikernel example and starting-point repository.
+
+#### Features
+
+* `Dhcp_server` supports a stripped down ISC dhcpd.conf, so you can probably just
+  use your old `dhcpd.conf`. It also supports manual configuration building in
+  OCaml.
+* `Dhcp_wire` provides marshalling and unmarshalling utilities for DHCP, it is the
+  base for `Dhcp_server`.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+"""

--- a/charrua-unix.opam
+++ b/charrua-unix.opam
@@ -1,18 +1,18 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name: "charrua-unix"
 maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
 authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
 homepage: "https://github.com/haesbaert/charrua-unix"
 bug-reports: "https://github.com/haesbaert/charrua-unix/issues"
 license: "ISC"
-dev-repo: "https://github.com/haesbaert/charrua-unix.git"
-available: [ocaml-version >= "4.03.0" & opam-version >= "1.2"]
+dev-repo: "git+https://github.com/haesbaert/charrua-unix.git"
 build: [
   ["jbuilder" "subst" "-n" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
+  "ocaml" {>= "4.03.0"}
   "lwt" {>="3.0.0"}
   "lwt_log"
   "charrua-core" {>= "0.10"}
@@ -22,3 +22,8 @@ depends: [
   "tuntap" {>= "1.2.0"}
   "mtime" {>="1.0.0"}
 ]
+synopsis: "Unix DHCP daemon"
+description: """
+charrua-unix is an _ISC-licensed_ Unix DHCP daemon based on
+[charrua-core](http://www.github.com/mirage/charrua-core).
+"""

--- a/client/dhcp_client.ml
+++ b/client/dhcp_client.ml
@@ -142,13 +142,9 @@ let offer t ~xid ~chaddr ~server_ip ~request_ip ~offer_options =
 (* make a new DHCP client. allow the user to request a specific xid, any
    requests, and the MAC address to use as the source for Ethernet messages and
    the chaddr in the fixed-length part of the message *)
-let create ?with_xid ?requests srcmac =
+let create ?requests xid srcmac =
   let open Constants in
   let open Dhcp_wire in
-  let xid = match with_xid with
-  | None -> Stdlibrandom.initialize (); Cstruct.BE.get_uint32 (Stdlibrandom.generate 4) 0
-  | Some xid -> xid
-  in
   let requests = match requests with
   | None | Some [] -> default_requests
   | Some requests -> requests
@@ -212,7 +208,7 @@ let input t buf =
     | Some DHCPACK, Renewing _
     | Some DHCPACK, Requesting _ -> `New_lease ({t with state = Bound incoming}, incoming)
     | Some DHCPNAK, Requesting _ | Some DHCPNAK, Renewing _ ->
-      `Response (create ~with_xid:(xid t) ~requests:t.request_options t.srcmac)
+      `Response (create ~requests:t.request_options (xid t) t.srcmac)
     | Some DHCPACK, Selecting _ (* too soon *)
     | Some DHCPACK, Bound _ -> (* too late *)
       `Noop

--- a/client/dhcp_client.mli
+++ b/client/dhcp_client.mli
@@ -4,11 +4,11 @@ type buffer = Cstruct.t
 
 val pp : Format.formatter -> t -> unit
 
-val create : ?with_xid : Cstruct.uint32 -> ?requests : Dhcp_wire.option_code list -> Macaddr.t -> (t * buffer)
-(** [create mac] returns a pair of [t, buffer].  [t] represents the current 
+val create : ?requests : Dhcp_wire.option_code list -> Cstruct.uint32 -> Macaddr.t -> (t * buffer)
+(** [create xid mac] returns a pair of [t, buffer].  [t] represents the current
  * state of the client in the lease transaction, and [buffer] is the suggested
  * next packet the caller should take to progress toward accepting a lease.
- * The optional argument [with_xid] allows the caller to specify a transaction ID
+ * The argument [xid] allows the caller to specify a transaction ID
  * to use for the lease attempt.
  * [requests] is a list of option codes which the client should ask for in its
  * attempt to get a DHCP lease.  If [requests] is not given, we'll make an educated

--- a/client/lwt/dhcp_client_lwt.mli
+++ b/client/lwt/dhcp_client_lwt.mli
@@ -1,11 +1,11 @@
-module Make(Time : Mirage_time_lwt.S) (Net : Mirage_net_lwt.S) : sig
+module Make(Random : Mirage_random.C)(Time : Mirage_time_lwt.S) (Net : Mirage_net_lwt.S) : sig
   type lease = Dhcp_wire.pkt
 
   type t = lease Lwt_stream.t
 
-  val connect : ?renew:bool -> ?with_xid : Cstruct.uint32 ->
+  val connect : ?renew:bool -> ?xid:Cstruct.uint32 ->
     ?requests:Dhcp_wire.option_code list -> Net.t -> t Lwt.t
-  (** [connect renew with_xid requests net] starts a DHCP client communicating
+  (** [connect renew ~xid requests net] starts a DHCP client communicating
       over the network interface [net].  The client will attempt to get a DHCP
       lease at least once, and will return any leases obtained in the stream
       returned by [connect].  If [renew] is true, which it is by default,

--- a/client/mirage/dhcp_client_mirage.ml
+++ b/client/mirage/dhcp_client_mirage.ml
@@ -19,14 +19,14 @@ let config_of_lease lease : Mirage_protocols_lwt.ipv4_config option =
     | hd::_ ->
       Some Mirage_protocols_lwt.{ address; network; gateway = (Some hd) }
 
-module Make(Time : Mirage_types_lwt.TIME) (Net : Mirage_types_lwt.NETWORK) = struct
+module Make(Random : Mirage_random.C)(Time : Mirage_types_lwt.TIME) (Net : Mirage_types_lwt.NETWORK) = struct
   open Lwt.Infix
   open Mirage_protocols_lwt
 
   type t = ipv4_config Lwt_stream.t
 
   let connect ?(requests : Dhcp_wire.option_code list option) net =
-    let module Lwt_client = Dhcp_client_lwt.Make(Time)(Net) in
+    let module Lwt_client = Dhcp_client_lwt.Make(Random)(Time)(Net) in
     Lwt_client.connect ~renew:false ?requests net >>= fun lease_stream ->
     Lwt.return @@ Lwt_stream.filter_map config_of_lease lease_stream
 

--- a/client/mirage/dhcp_client_mirage.mli
+++ b/client/mirage/dhcp_client_mirage.mli
@@ -1,4 +1,4 @@
-module Make(Time : Mirage_types_lwt.TIME) (Network : Mirage_types_lwt.NETWORK) : sig
+module Make(Random : Mirage_random.C)(Time : Mirage_types_lwt.TIME) (Network : Mirage_types_lwt.NETWORK) : sig
   type t = Mirage_protocols_lwt.ipv4_config Lwt_stream.t
   val connect : ?requests:Dhcp_wire.option_code list
     -> Network.t -> t Lwt.t

--- a/test/client/jbuild
+++ b/test/client/jbuild
@@ -2,7 +2,7 @@
 
 (executables
  ((names (test_client))
-  (libraries (cstruct-unix alcotest charrua-client charrua-core.server tcpip.unix))))
+  (libraries (cstruct-unix alcotest charrua-client charrua-core.server tcpip.unix mirage-random-test))))
 
 (alias
  ((name    runtest)

--- a/test/client/lwt/test_client_lwt.ml
+++ b/test/client/lwt/test_client_lwt.ml
@@ -2,6 +2,12 @@ open Lwt.Infix
 
 (* additional tests for time- and network-dependent code *)
 
+module No_random = struct
+  type buffer = Cstruct.t
+  type g
+  let generate ?g n = Cstruct.create n
+end
+
 module No_time = struct
   type 'a io = 'a Lwt.t
   let sleep_ns n = Format.printf "Ignoring request to wait %f seconds\n" @@ Duration.to_f n;
@@ -39,7 +45,7 @@ end
 
 let keep_trying () =
   Lwt_main.run @@ (
-    let module Client = Dhcp_client_lwt.Make(No_time)(No_net) in
+    let module Client = Dhcp_client_lwt.Make(No_random)(No_time)(No_net) in
     let net = No_net.connect ~mac:(Macaddr.of_string_exn "c0:ff:ee:c0:ff:ee") () in
     let test =
       Client.connect net >>= Lwt_stream.get >|= function


### PR DESCRIPTION
rework usage of randomness in Dhcp_client
    
Dhcp_client.create used to call into Stdlibrandom (provided by mirage-random <=1.1.0).

Dhcp_client_lwt already depends on Mirage libraries, I added the Mirage_random.C signature, and provide the random xid, if necessary, in Dhcp_client_lwt.

see https://github.com/mirage/mirage/pull/938 for changes in mirage