### PR TITLE
adapt to ipv4 fragmentation changes, use ipaddr 3.0

### DIFF
--- a/charrua-client-lwt.opam
+++ b/charrua-client-lwt.opam
@@ -21,7 +21,7 @@ depends: [
   "charrua-core" {>= "0.11.0"}
   "charrua-client" {>= "0.11.0"}
   "cstruct" {>="3.0.2"}
-  "ipaddr"
+  "ipaddr" {>="3.0.0"}
   "rresult"
   "mirage-random" {>= "1.0.0"}
   "duration"

--- a/charrua-client-lwt.opam
+++ b/charrua-client-lwt.opam
@@ -26,11 +26,11 @@ depends: [
   "mirage-random" {>= "1.0.0"}
   "duration"
   "mirage-time-lwt"
+  "mirage-net-lwt"
   "logs"
-  "tcpip" {>= "3.2.0"}
+  "tcpip" {>= "3.6.0"}
   "fmt"
   "lwt"
-  "mirage-types-lwt" {>="3.0.0"}
 ]
 synopsis: "A DHCP client using lwt as effectful layer"
 description: """

--- a/charrua-client-mirage.opam
+++ b/charrua-client-mirage.opam
@@ -19,16 +19,18 @@ depends: [
   "charrua-client-lwt" {>= "0.11.0"}
   "charrua-client" {>= "0.11.0"}
   "cstruct" {>="3.0.2"}
-  "ipaddr"
+  "ipaddr" {>= "3.0.0"}
   "rresult"
   "mirage-random" {>= "1.0.0"}
   "mirage-clock"
+  "mirage-time-lwt"
+  "mirage-net-lwt"
+  "mirage-protocols-lwt"
   "duration"
   "logs"
-  "tcpip" {>= "3.5.0"}
+  "tcpip" {>= "3.6.0"}
   "fmt"
   "lwt"
-  "mirage-types-lwt" {>="3.0.0"}
 ]
 synopsis: "A DHCP client for MirageOS"
 description: """

--- a/charrua-client.opam
+++ b/charrua-client.opam
@@ -22,6 +22,7 @@ depends: [
   "charrua-core" {>= "0.11.0"}
   "cstruct" {>="3.0.2"}
   "ipaddr"
+  "macaddr"
 ]
 synopsis: "DHCP client implementation"
 description: """

--- a/charrua-core.opam
+++ b/charrua-core.opam
@@ -21,7 +21,8 @@ depends: [
   "ocaml"         {>= "4.0.3"}
   "cstruct"       {>= "3.0.1"}
   "sexplib"
-  "ipaddr"        {>= "2.5.0"}
+  "ipaddr"        {>= "3.0.0"}
+  "macaddr"
   "tcpip"         {>= "3.2.0"}
   "rresult"
   "io-page-unix"  {with-test}

--- a/charrua-core.opam
+++ b/charrua-core.opam
@@ -23,7 +23,7 @@ depends: [
   "sexplib"
   "ipaddr"        {>= "3.0.0"}
   "macaddr"
-  "tcpip"         {>= "3.2.0"}
+  "tcpip"         {>= "3.6.0"}
   "rresult"
   "io-page-unix"  {with-test}
   "cstruct-unix"  {with-test}

--- a/client/dhcp_client.ml
+++ b/client/dhcp_client.ml
@@ -75,7 +75,7 @@ let pp fmt p =
     | Renewing (ack, request) -> Format.fprintf fmt
         "RENEWING.  Have lease %s, generated request %s" (pr ack) (pr request)
   in
-  Format.fprintf fmt "%s: %a" (Macaddr.to_string p.srcmac) pp_state p.state
+  Format.fprintf fmt "%a: %a" Macaddr.pp p.srcmac pp_state p.state
 
 (* the lease function lets callers know whether the abstract (to them) lease
    object carries a usable network configuration. *)

--- a/client/lwt/dhcp_client_lwt.ml
+++ b/client/lwt/dhcp_client_lwt.ml
@@ -73,8 +73,8 @@ module Make(Random : Mirage_random.C)(Time : Mirage_time_lwt.S) (Net : Mirage_ne
           let open Dhcp_wire in
           (* a lease is obtained! Note it, and replace the current listener *)
           Log.info (fun f -> f "Lease obtained! IP: %a, routers: %a"
-          Ipaddr.V4.pp_hum l.yiaddr
-          (Fmt.list Ipaddr.V4.pp_hum) (collect_routers l.options));
+          Ipaddr.V4.pp l.yiaddr
+          (Fmt.list Ipaddr.V4.pp) (collect_routers l.options));
           push @@ Some l;
           c := s;
           match renew with

--- a/client/lwt/jbuild
+++ b/client/lwt/jbuild
@@ -5,4 +5,4 @@
   (public_name charrua-client-lwt)
   (modules     (dhcp_client_lwt))
   (libraries   (charrua-core.wire lwt charrua-client
-                mirage-time-lwt duration))))
+                mirage-time-lwt mirage-random mirage-net-lwt duration))))

--- a/client/mirage/dhcp_client_mirage.ml
+++ b/client/mirage/dhcp_client_mirage.ml
@@ -19,7 +19,7 @@ let config_of_lease lease : Mirage_protocols_lwt.ipv4_config option =
     | hd::_ ->
       Some Mirage_protocols_lwt.{ address; network; gateway = (Some hd) }
 
-module Make(Random : Mirage_random.C)(Time : Mirage_types_lwt.TIME) (Net : Mirage_types_lwt.NETWORK) = struct
+module Make(Random : Mirage_random.C)(Time : Mirage_time_lwt.S) (Net : Mirage_net_lwt.S) = struct
   open Lwt.Infix
   open Mirage_protocols_lwt
 

--- a/client/mirage/dhcp_client_mirage.mli
+++ b/client/mirage/dhcp_client_mirage.mli
@@ -1,4 +1,4 @@
-module Make(Random : Mirage_random.C)(Time : Mirage_types_lwt.TIME) (Network : Mirage_types_lwt.NETWORK) : sig
+module Make(Random : Mirage_random.C)(Time : Mirage_time_lwt.S) (Network : Mirage_net_lwt.S) : sig
   type t = Mirage_protocols_lwt.ipv4_config Lwt_stream.t
   val connect : ?requests:Dhcp_wire.option_code list
     -> Network.t -> t Lwt.t

--- a/client/mirage/dhcp_ipv4.mli
+++ b/client/mirage/dhcp_ipv4.mli
@@ -14,8 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (D: Mirage_protocols_lwt.DHCP_CLIENT) (R : Mirage_random.C) (C : Mirage_clock.MCLOCK) (E:Mirage_types_lwt.ETHIF) (A: Mirage_types_lwt.ARP) : sig
-  include Mirage_types_lwt.IPV4
+module Make (D: Mirage_protocols_lwt.DHCP_CLIENT) (R : Mirage_random.C) (C : Mirage_clock.MCLOCK) (E:Mirage_protocols_lwt.ETHIF) (A: Mirage_protocols_lwt.ARP) : sig
+  include Mirage_protocols_lwt.IPV4
   val connect : D.t -> C.t -> E.t -> A.t -> t Lwt.t
     (** Connect to an ipv4 device using information from a DHCP lease. *)
 end

--- a/client/mirage/jbuild
+++ b/client/mirage/jbuild
@@ -2,5 +2,5 @@
 (library
  ((name        dhcp_client_mirage)
   (public_name charrua-client-mirage)
-  (libraries   (charrua-client-lwt mirage-types-lwt mirage-protocols-lwt mirage-clock mirage-random))
+  (libraries   (charrua-client-lwt mirage-clock mirage-random mirage-time-lwt mirage-net-lwt mirage-protocols-lwt))
   (wrapped false)))

--- a/lib/dhcp_server.ml
+++ b/lib/dhcp_server.ml
@@ -21,8 +21,8 @@ module Config = struct
   type host = {
     hostname : string;
     options : Dhcp_wire.dhcp_option list;
-    fixed_addr : Ipaddr.V4.t option;
-    hw_addr : Macaddr.t;
+    fixed_addr : Ipaddr_sexp.V4.t option;
+    hw_addr : Macaddr_sexp.t;
   } [@@deriving sexp]
 
   type t = {
@@ -30,10 +30,10 @@ module Config = struct
     hostname : string;
     default_lease_time : int32;
     max_lease_time : int32;
-    ip_addr : Ipaddr.V4.t;
-    mac_addr : Macaddr.t;
-    network : Ipaddr.V4.Prefix.t;
-    range : (Ipaddr.V4.t * Ipaddr.V4.t) option;
+    ip_addr : Ipaddr_sexp.V4.t;
+    mac_addr : Macaddr_sexp.t;
+    network : Ipaddr_sexp.V4.Prefix.t;
+    range : (Ipaddr_sexp.V4.t * Ipaddr_sexp.V4.t) option;
     hosts : host list;
   } [@@deriving sexp]
 
@@ -194,7 +194,7 @@ module Lease = struct
   type t = {
     tm_start   : int32;
     tm_end     : int32;
-    addr       : Ipaddr.V4.t;
+    addr       : Ipaddr_sexp.V4.t;
     client_id  : Dhcp_wire.client_id;
   } [@@deriving sexp]
 

--- a/lib/dhcp_wire.ml
+++ b/lib/dhcp_wire.ml
@@ -1104,6 +1104,7 @@ let pkt_of_buf buf len =
   try wrap () with | Invalid_argument e -> Error e
 
 let buf_of_pkt pkt =
+  (* TODO mtu *)
   let dhcp = Cstruct.create 2048 in
   set_dhcp_op dhcp (op_to_int pkt.op);
   set_dhcp_htype dhcp
@@ -1158,6 +1159,7 @@ let buf_of_pkt pkt =
   in
   let ip = Ipv4_packet.(Marshal.make_cstruct ~payload_len:(Cstruct.lenv [udp;dhcp])
                           { src = pkt.srcip; dst = pkt.dstip;
+                            id = 0 (* TODO: random? *); off = 0 ;
                             proto = (Marshal.protocol_to_int `UDP);
                             ttl = 255;
                             options = Cstruct.create 0; })

--- a/lib/dhcp_wire.ml
+++ b/lib/dhcp_wire.ml
@@ -340,44 +340,44 @@ type flags =
   | Unicast [@@deriving sexp]
 
 type client_id =
-  | Hwaddr of Macaddr.t
+  | Hwaddr of Macaddr_sexp.t
   | Id of string [@@deriving sexp]
 
 type dhcp_option =
   | Pad                                     (* code 0 *)
-  | Subnet_mask of Ipaddr.V4.t              (* code 1 *)
+  | Subnet_mask of Ipaddr_sexp.V4.t         (* code 1 *)
   | Time_offset of int32                    (* code 2 *)
-  | Routers of Ipaddr.V4.t list             (* code 3 *)
-  | Time_servers of Ipaddr.V4.t list        (* code 4 *)
-  | Name_servers of Ipaddr.V4.t list        (* code 5 *)
-  | Dns_servers of Ipaddr.V4.t list         (* code 6 *)
-  | Log_servers of Ipaddr.V4.t list         (* code 7 *)
-  | Cookie_servers of Ipaddr.V4.t list      (* code 8 *)
-  | Lpr_servers of Ipaddr.V4.t list         (* code 9 *)
-  | Impress_servers of Ipaddr.V4.t list     (* code 10 *)
-  | Rsclocation_servers of Ipaddr.V4.t list (* code 11 *)
+  | Routers of Ipaddr_sexp.V4.t list        (* code 3 *)
+  | Time_servers of Ipaddr_sexp.V4.t list        (* code 4 *)
+  | Name_servers of Ipaddr_sexp.V4.t list        (* code 5 *)
+  | Dns_servers of Ipaddr_sexp.V4.t list         (* code 6 *)
+  | Log_servers of Ipaddr_sexp.V4.t list         (* code 7 *)
+  | Cookie_servers of Ipaddr_sexp.V4.t list      (* code 8 *)
+  | Lpr_servers of Ipaddr_sexp.V4.t list         (* code 9 *)
+  | Impress_servers of Ipaddr_sexp.V4.t list     (* code 10 *)
+  | Rsclocation_servers of Ipaddr_sexp.V4.t list (* code 11 *)
   | Hostname of string                      (* code 12 *)
   | Bootfile_size of int                    (* code 13 *)
   | Merit_dumpfile of string                (* code 14 *)
   | Domain_name of string                   (* code 15 *)
-  | Swap_server of Ipaddr.V4.t              (* code 16 *)
+  | Swap_server of Ipaddr_sexp.V4.t              (* code 16 *)
   | Root_path of string                     (* code 17 *)
   | Extension_path of string                (* code 18 *)
   | Ipforwarding of bool                    (* code 19 *)
   | Nlsr of bool                            (* code 20 *)
-  | Policy_filters of Ipaddr.V4.Prefix.t list (* code 21 *)
+  | Policy_filters of Ipaddr_sexp.V4.Prefix.t list (* code 21 *)
   | Max_datagram of int                     (* code 22 *)
   | Default_ip_ttl of int                   (* code 23 *)
   | Pmtu_ageing_timo of int32               (* code 24 *)
   | Pmtu_plateau_table of int list          (* code 25 *)
   | Interface_mtu of int                    (* code 26 *)
   | All_subnets_local of bool               (* code 27 *)
-  | Broadcast_addr of Ipaddr.V4.t           (* code 28 *)
+  | Broadcast_addr of Ipaddr_sexp.V4.t           (* code 28 *)
   | Perform_mask_discovery of bool          (* code 29 *)
   | Mask_supplier of bool                   (* code 30 *)
   | Perform_router_disc of bool             (* code 31 *)
-  | Router_sol_addr of Ipaddr.V4.t          (* code 32 *)
-  | Static_routes of (Ipaddr.V4.t * Ipaddr.V4.t) list (* code 33 *)
+  | Router_sol_addr of Ipaddr_sexp.V4.t          (* code 32 *)
+  | Static_routes of (Ipaddr_sexp.V4.t * Ipaddr_sexp.V4.t) list (* code 33 *)
   | Trailer_encapsulation of bool           (* code 34 *)
   | Arp_cache_timo of int32                 (* code 35 *)
   | Ethernet_encapsulation of bool          (* code 36 *)
@@ -385,20 +385,20 @@ type dhcp_option =
   | Tcp_keepalive_interval of int32         (* code 38 *)
   | Tcp_keepalive_garbage of int            (* code 39 *)
   | Nis_domain of string                    (* code 40 *)
-  | Nis_servers of Ipaddr.V4.t list         (* code 41 *)
-  | Ntp_servers of Ipaddr.V4.t list         (* code 42 *)
+  | Nis_servers of Ipaddr_sexp.V4.t list         (* code 41 *)
+  | Ntp_servers of Ipaddr_sexp.V4.t list         (* code 42 *)
   | Vendor_specific of string               (* code 43 *)
-  | Netbios_name_servers of Ipaddr.V4.t list(* code 44 *)
-  | Netbios_datagram_distrib_servers of Ipaddr.V4.t list (* code 45 *)
+  | Netbios_name_servers of Ipaddr_sexp.V4.t list(* code 44 *)
+  | Netbios_datagram_distrib_servers of Ipaddr_sexp.V4.t list (* code 45 *)
   | Netbios_node of int                     (* code 46 *)
   | Netbios_scope of string                 (* code 47 *)
-  | Xwindow_font_servers of Ipaddr.V4.t list(* code 48 *)
-  | Xwindow_display_managers of Ipaddr.V4.t list (* code 49 *)
-  | Request_ip of Ipaddr.V4.t               (* code 50 *)
+  | Xwindow_font_servers of Ipaddr_sexp.V4.t list(* code 48 *)
+  | Xwindow_display_managers of Ipaddr_sexp.V4.t list (* code 49 *)
+  | Request_ip of Ipaddr_sexp.V4.t               (* code 50 *)
   | Ip_lease_time of int32                  (* code 51 *)
   | Option_overload of int                  (* code 52 *)
   | Message_type of msgtype                 (* code 53 *)
-  | Server_identifier of Ipaddr.V4.t        (* code 54 *)
+  | Server_identifier of Ipaddr_sexp.V4.t        (* code 54 *)
   | Parameter_requests of option_code list  (* code 55 *)
   | Message of string                       (* code 56 *)
   | Max_message of int                      (* code 57 *)
@@ -409,18 +409,18 @@ type dhcp_option =
   | Netware_ip_domain of string             (* code 62 *)
   | Netware_ip_option of string             (* code 63 *)
   | Nis_plus_domain of string               (* code 64 *)
-  | Nis_plus_servers of Ipaddr.V4.t list    (* code 65 *)
+  | Nis_plus_servers of Ipaddr_sexp.V4.t list    (* code 65 *)
   | Tftp_server_name of string              (* code 66 *)
   | Bootfile_name of string                 (* code 67 *)
-  | Mobile_ip_home_agent of Ipaddr.V4.t list(* code 68 *)
-  | Smtp_servers of Ipaddr.V4.t list        (* code 69 *)
-  | Pop3_servers of Ipaddr.V4.t list        (* code 70 *)
-  | Nntp_servers of Ipaddr.V4.t list        (* code 71 *)
-  | Www_servers of Ipaddr.V4.t list         (* code 72 *)
-  | Finger_servers of Ipaddr.V4.t list      (* code 73 *)
-  | Irc_servers of Ipaddr.V4.t list         (* code 74 *)
-  | Streettalk_servers of Ipaddr.V4.t list  (* code 75 *)
-  | Streettalk_da of Ipaddr.V4.t list       (* code 76 *)
+  | Mobile_ip_home_agent of Ipaddr_sexp.V4.t list(* code 68 *)
+  | Smtp_servers of Ipaddr_sexp.V4.t list        (* code 69 *)
+  | Pop3_servers of Ipaddr_sexp.V4.t list        (* code 70 *)
+  | Nntp_servers of Ipaddr_sexp.V4.t list        (* code 71 *)
+  | Www_servers of Ipaddr_sexp.V4.t list         (* code 72 *)
+  | Finger_servers of Ipaddr_sexp.V4.t list      (* code 73 *)
+  | Irc_servers of Ipaddr_sexp.V4.t list         (* code 74 *)
+  | Streettalk_servers of Ipaddr_sexp.V4.t list  (* code 75 *)
+  | Streettalk_da of Ipaddr_sexp.V4.t list  (* code 76 *)
   | User_class of string                    (* code 77 *)
   | Directory_agent of string               (* code 78 *)
   | Service_scope of string                 (* code 79 *)
@@ -432,10 +432,10 @@ type dhcp_option =
   | Nds_tree_name of string                 (* code 86 *)
   | Nds_context of string                   (* code 87 *)
   | Bcmcs_controller_domain_name_list of string (* code 88 *)
-  | Bcmcs_controller_ipv4_addrs of Ipaddr.V4.t list (* code 89 *)
+  | Bcmcs_controller_ipv4_addrs of Ipaddr_sexp.V4.t list (* code 89 *)
   | Authentication of string                (* code 90 *)
   | Client_last_transaction_time of int32   (* code 91 *)
-  | Associated_ips of Ipaddr.V4.t list      (* code 92 *)
+  | Associated_ips of Ipaddr_sexp.V4.t list (* code 92 *)
   | Client_system of string                 (* code 93 *)
   | Client_ndi of string                    (* code 94 *)
   | Ldap of string                          (* code 95 *)
@@ -449,7 +449,7 @@ type dhcp_option =
   | Url of string                           (* code 114 *)
   | Auto_config of int                      (* code 116 *)
   | Name_service_search of string           (* code 117 *)
-  | Subnet_selection of Ipaddr.V4.t         (* code 118 *)
+  | Subnet_selection of Ipaddr_sexp.V4.t    (* code 118 *)
   | Domain_search of string                 (* code 119 *)
   | Sip_servers of string                   (* code 120 *)
   | Classless_static_route of string        (* code 121 *) (* XXX current, use better type *)
@@ -504,10 +504,10 @@ type dhcp_option =
   [@@deriving sexp]
 
 type pkt = {
-  srcmac  : Macaddr.t;
-  dstmac  : Macaddr.t;
-  srcip   : Ipaddr.V4.t;
-  dstip   : Ipaddr.V4.t;
+  srcmac  : Macaddr_sexp.t;
+  dstmac  : Macaddr_sexp.t;
+  srcip   : Ipaddr_sexp.V4.t;
+  dstip   : Ipaddr_sexp.V4.t;
   srcport : int;
   dstport : int;
   op      : op;
@@ -517,11 +517,11 @@ type pkt = {
   xid     : int32;
   secs    : int;
   flags   : flags;
-  ciaddr  : Ipaddr.V4.t;
-  yiaddr  : Ipaddr.V4.t;
-  siaddr  : Ipaddr.V4.t;
-  giaddr  : Ipaddr.V4.t;
-  chaddr  : Macaddr.t;
+  ciaddr  : Ipaddr_sexp.V4.t;
+  yiaddr  : Ipaddr_sexp.V4.t;
+  siaddr  : Ipaddr_sexp.V4.t;
+  giaddr  : Ipaddr_sexp.V4.t;
+  chaddr  : Macaddr_sexp.t;
   sname   : string;
   file    : string;
   options : dhcp_option list;

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -4,7 +4,7 @@
   (modules (dhcp_wire util))
   (wrapped false)
   (preprocess (pps (ppx_sexp_conv ppx_cstruct -no-check)))
-  (libraries   (tcpip.ethif tcpip.ipv4 tcpip.udp))
+  (libraries   (tcpip.ethif tcpip.ipv4 tcpip.udp ipaddr ipaddr.sexp macaddr macaddr.sexp))
 ))
 
 (library
@@ -13,7 +13,7 @@
   (modules (dhcp_server dhcp_lexer dhcp_parser ast))
   (wrapped false)
   (preprocess (pps (ppx_sexp_conv ppx_cstruct -no-check)))
-  (libraries   (ipaddr rresult tcpip charrua-core.wire))
+  (libraries   (ipaddr ipaddr.sexp macaddr macaddr.sexp rresult tcpip charrua-core.wire))
 ))
 
 (menhir ((modules (dhcp_parser))))


### PR DESCRIPTION
since https://github.com/mirage/mirage-tcpip/pull/375 was merged, required API changes to dhcp_wire.ml