### PR TITLE
Rename ethif to ethernet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
   - TESTS=true
   - PINS="charrua-core.dev:. charrua-unix.dev:. charrua-client.dev:. charrua-client-lwt.dev:. charrua-client-mirage.dev:."
-  - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
+  - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git#layering"
   matrix:
   - DISTRO="alpine" OCAML_VERSION="4.06" PACKAGE="charrua-client"
   - DISTRO="alpine" OCAML_VERSION="4.06" PACKAGE="charrua-client-lwt"

--- a/charrua-client-lwt.opam
+++ b/charrua-client-lwt.opam
@@ -18,15 +18,15 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "alcotest"     {with-test}
   "cstruct-unix" {with-test}
-  "charrua-core" {>= "0.11.1"}
-  "charrua-client" {>= "0.11.1"}
+  "charrua-core" {>= "0.12.0"}
+  "charrua-client" {>= "0.12.0"}
   "cstruct" {>="3.0.2"}
   "ipaddr" {>="3.0.0"}
   "rresult"
   "mirage-random" {>= "1.0.0"}
   "duration"
   "mirage-time-lwt"
-  "mirage-net-lwt"
+  "mirage-net-lwt" {>= "2.0.0"}
   "logs"
   "tcpip" {>= "3.6.0"}
   "fmt"

--- a/charrua-client-mirage.opam
+++ b/charrua-client-mirage.opam
@@ -15,9 +15,9 @@ build: [
 depends: [
   "dune" {build & >= "1.0"}
   "ocaml" {>= "4.04.2"}
-  "charrua-core" {>= "0.11.1"}
-  "charrua-client-lwt" {>= "0.11.1"}
-  "charrua-client" {>= "0.11.1"}
+  "charrua-core" {>= "0.12.0"}
+  "charrua-client-lwt" {>= "0.12.0"}
+  "charrua-client" {>= "0.12.0"}
   "cstruct" {>="3.0.2"}
   "ipaddr" {>= "3.0.0"}
   "rresult"

--- a/charrua-client.opam
+++ b/charrua-client.opam
@@ -19,7 +19,7 @@ depends: [
   "alcotest"     {with-test}
   "cstruct-unix" {with-test}
   "mirage-random-test" {with-test}
-  "charrua-core" {>= "0.11.1"}
+  "charrua-core" {>= "0.12.0"}
   "cstruct" {>="3.0.2"}
   "ipaddr"
   "macaddr"

--- a/charrua-core.opam
+++ b/charrua-core.opam
@@ -26,7 +26,6 @@ depends: [
   "ethernet"
   "tcpip"         {>= "3.7.0"}
   "rresult"
-  "io-page-unix"  {with-test}
   "cstruct-unix"  {with-test}
 ]
 synopsis: "DHCP wire frame encoder and decoder"

--- a/charrua-unix.opam
+++ b/charrua-unix.opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "lwt" {>="3.0.0"}
   "lwt_log"
-  "charrua-core" {>= "0.11.0"}
+  "charrua-core" {>= "0.12.0"}
   "cstruct-unix"
   "cmdliner"
   "rawlink" {>= "1.0"}

--- a/client/dhcp_client.mli
+++ b/client/dhcp_client.mli
@@ -1,10 +1,9 @@
 type t
-type buffer = Cstruct.t
 (** we expect all serialization and deserialization to happen through Cstruct.t *)
 
 val pp : Format.formatter -> t -> unit
 
-val create : ?requests : Dhcp_wire.option_code list -> Cstruct.uint32 -> Macaddr.t -> (t * buffer)
+val create : ?requests : Dhcp_wire.option_code list -> Cstruct.uint32 -> Macaddr.t -> (t * Dhcp_wire.pkt)
 (** [create xid mac] returns a pair of [t, buffer].  [t] represents the current
  * state of the client in the lease transaction, and [buffer] is the suggested
  * next packet the caller should take to progress toward accepting a lease.
@@ -15,7 +14,7 @@ val create : ?requests : Dhcp_wire.option_code list -> Cstruct.uint32 -> Macaddr
  * guess rather than requesting nothing.
  *)
 
-val input : t -> buffer -> [`Response of (t * buffer) | `New_lease of (t * Dhcp_wire.pkt) | `Noop ]
+val input : t -> Cstruct.t -> [`Response of t * Dhcp_wire.pkt | `New_lease of t * Dhcp_wire.pkt | `Noop ]
 (** [input t buf] attempts to advance the state of [t]
  * with the contents of [buf].  If [buf] is invalid or not useful given
  * the current state of [t], [`Noop] is returned indicating no action should be taken.
@@ -32,7 +31,7 @@ val lease : t -> Dhcp_wire.pkt option
  * necessary.
  * If [t] hasn't yet completed a lease transaction, [None] will be returned. *)
 
-val renew : t -> [`Response of (t * buffer) | `Noop]
+val renew : t -> [`Response of t * Dhcp_wire.pkt | `Noop]
 (** [renew t] returns either a [`Response] with the next state and suggested action
  * of the client attempting to renew [t]'s lease,
  * or [`Noop] if [t] does not have a lease and therefore can't be renewed. *)

--- a/client/mirage/dhcp_ipv4.ml
+++ b/client/mirage/dhcp_ipv4.ml
@@ -1,10 +1,10 @@
 open Lwt.Infix
 open Mirage_protocols_lwt
 
-module Make(Dhcp_client : DHCP_CLIENT) (R : Mirage_random.C) (C : Mirage_clock.MCLOCK) (Ethif : ETHIF)(Arp : ARP) = struct
+module Make(Dhcp_client : DHCP_CLIENT) (R : Mirage_random.C) (C : Mirage_clock.MCLOCK) (E : ETHERNET) (Arp : ARP) = struct
   (* for now, just wrap a static ipv4 *)
-  include Static_ipv4.Make(R)(C)(Ethif)(Arp)
-  let connect dhcp clock ethif arp =
+  include Static_ipv4.Make(R)(C)(E)(Arp)
+  let connect dhcp clock ethernet arp =
     Lwt_stream.last_new dhcp >>= fun (config : ipv4_config) ->
-    connect ~ip:config.address ~network:config.network ~gateway:config.gateway clock ethif arp
+    connect ~ip:config.address ~network:config.network ~gateway:config.gateway clock ethernet arp
 end

--- a/client/mirage/dhcp_ipv4.mli
+++ b/client/mirage/dhcp_ipv4.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (D: Mirage_protocols_lwt.DHCP_CLIENT) (R : Mirage_random.C) (C : Mirage_clock.MCLOCK) (E:Mirage_protocols_lwt.ETHIF) (A: Mirage_protocols_lwt.ARP) : sig
+module Make (D: Mirage_protocols_lwt.DHCP_CLIENT) (R : Mirage_random.C) (C : Mirage_clock.MCLOCK) (E:Mirage_protocols_lwt.ETHERNET) (A: Mirage_protocols_lwt.ARP) : sig
   include Mirage_protocols_lwt.IPV4
   val connect : D.t -> C.t -> E.t -> A.t -> t Lwt.t
     (** Connect to an ipv4 device using information from a DHCP lease. *)

--- a/lib/dhcp_wire.mli
+++ b/lib/dhcp_wire.mli
@@ -754,6 +754,7 @@ type pkt = {
 
 val pkt_of_buf : Cstruct.t -> int -> (pkt, string) result
 val buf_of_pkt : pkt -> Cstruct.t
+val pkt_into_buf : pkt -> Cstruct.t -> int
 
 val pkt_of_sexp : Sexplib.Sexp.t -> pkt
 val sexp_of_pkt : pkt -> Sexplib.Sexp.t

--- a/test/client/lwt/test_client_lwt.ml
+++ b/test/client/lwt/test_client_lwt.ml
@@ -23,15 +23,14 @@ module No_net = struct
   type buffer = Cstruct.t
   type t = { mac : Macaddr.t; mutable packets : Cstruct.t list }
   let disconnect _ = Lwt.return_unit
-  let write t ?size fillf =
-    let size = 14 + match size with None -> 1500 | Some s -> s in
+  let write t ~size fillf =
     let buf = Cstruct.create size in
-    let l = 14 + fillf buf in
+    let l = fillf buf in
     assert (l <= size);
     let b = Cstruct.sub buf 0 l in
     t.packets <- t.packets @ [b];
     Lwt.return_ok ()
-  let listen _ _ = Lwt.return_ok ()
+  let listen _ ~header_size:_ _ = Lwt.return_ok ()
   let mac t = t.mac
   let mtu t = 1500
   let reset_stats_counters _ = ()

--- a/test/client/lwt/test_client_lwt.ml
+++ b/test/client/lwt/test_client_lwt.ml
@@ -15,23 +15,25 @@ module No_time = struct
 end
 
 module No_net = struct
-  type error = Mirage_device.error
-  let pp_error = Mirage_device.pp_error
+  type error = Mirage_net.Net.error
+  let pp_error = Mirage_net.Net.pp_error
   type stats = Mirage_net.stats
   type 'a io = 'a Lwt.t
   type macaddr = Macaddr.t
-  type page_aligned_buffer = Io_page.t
   type buffer = Cstruct.t
   type t = { mac : Macaddr.t; mutable packets : Cstruct.t list }
   let disconnect _ = Lwt.return_unit
-  let writev t l =
-    t.packets <- t.packets @ l;
-    Lwt.return_ok ()
-  let write t p =
-    t.packets <- p :: t.packets;
+  let write t ?size fillf =
+    let size = 14 + match size with None -> 1500 | Some s -> s in
+    let buf = Cstruct.create size in
+    let l = 14 + fillf buf in
+    assert (l <= size);
+    let b = Cstruct.sub buf 0 l in
+    t.packets <- t.packets @ [b];
     Lwt.return_ok ()
   let listen _ _ = Lwt.return_ok ()
   let mac t = t.mac
+  let mtu t = 1500
   let reset_stats_counters _ = ()
   let get_stats_counters _ = {
     Mirage_net.rx_bytes = 0L;

--- a/test/dune
+++ b/test/dune
@@ -2,7 +2,7 @@
  (names test)
  (preprocess
   (pps ppx_cstruct))
- (libraries cstruct-unix io-page.unix charrua-core.server tcpip.unix))
+ (libraries cstruct-unix charrua-core.server tcpip.unix))
 
 (alias
  (name runtest)


### PR DESCRIPTION
this is on top of #94 and should be merged thereafter, but before a new release. see https://github.com/mirage/mirage-protocols/pull/16