### PR TITLE
Fix dhcp client id

### DIFF
--- a/lib/dhcp_wire.ml
+++ b/lib/dhcp_wire.ml
@@ -614,11 +614,10 @@ let options_of_buf buf buf_len =
           Cstruct.copy body 0 len
       in
       let get_client_id () =  if len < 2 then invalid_arg bad_len else
-          let s = Cstruct.copy body 1 (len - 1) in
           if (Cstruct.get_uint8 body 0) = 1 && len = 7 then
-            Hwaddr (Macaddr.of_bytes_exn s)
+            Hwaddr (Macaddr.of_bytes_exn (Cstruct.copy body 1 len))
           else
-            Id s
+            Id (Cstruct.copy body 0 len)
       in
       match code with
       | 0 ->   padding ()


### PR DESCRIPTION
Clients which uses a Client Id with type 0xff could not get an
dhcp lease.
The Problem is in the Client Id type of 0xff. Charrua ignored the type
and set it internal to 0x00. When the client sent the "Request",
charrua could not find the matching Offer because of the mismatch in the client
id.

client | server
-> DISCOVER
<- OFFER
-> REQUEST
<- NAK!

Note to previous self:
 - I've no idea how I fixed it. Can you explain it?