### PR TITLE
Add sexplib direct dependency

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -5,7 +5,7 @@
  (wrapped false)
  (preprocess
   (pps ppx_sexp_conv ppx_cstruct -- -no-check))
- (libraries ethernet tcpip.ipv4 tcpip.udp ipaddr ipaddr.sexp macaddr
+ (libraries ethernet sexplib tcpip.ipv4 tcpip.udp ipaddr ipaddr.sexp macaddr
    macaddr.sexp))
 
 (library


### PR DESCRIPTION
The library breaks with cstruct 4.0.0 as it removes the implicit sexplib dependency from the closure.
This PR just adds sexplib as a direct dependency. Hopefully this should allow us to lift the `cstruct < 4.0.0` condition that was forcing a lot of downgrades lately.